### PR TITLE
Mdebreceni/integrate mandelbrot kernel

### DIFF
--- a/mandelbrot/mandel-kernel.asm
+++ b/mandelbrot/mandel-kernel.asm
@@ -94,15 +94,13 @@ iterator_loop:
     ora #$80            ; fixup 
     sta zi+1
 
-    dec iterations
-    bne .return
-
-    ;; if we've maxed out fall through to bailoutMaxIterations
+    dec iterations  
+    bne .return   ;; or fall through if we've reached 0 iterations
 
 .bailoutMaxIterations:
     ; we've reached the maximum number of iterations. This point is in the set.
     ; iterations contains the pixel colour
-    lda 0
+    lda #0
     sta keepIterating
     jmp .return
 
@@ -110,6 +108,8 @@ iterator_loop:
 .bailoutToInfinityAndBeyond:
     ; |z^2| > 4, so we are out of the set.
     ; iterations contains the pixel colour
+    lda #0
+    sta keepIterating
     jmp .return
 
 .return:

--- a/mandelbrot/mandel-kernel.asm
+++ b/mandelbrot/mandel-kernel.asm
@@ -29,6 +29,7 @@ iterator_loop:
     adc zi, y         ; A = high(zr^2) + high(zi^2) = high(zr^2 + zi^2) 
     ;cmp #4 << (fraction_bits-8)
     ;cmp #4 << 1    ;; FIXME:  1 is a placeholder
+    cmp #2
     bcs .bailoutToInfinityAndBeyond
     sta zr2_p_zi2_hi
 

--- a/mandelbrot/mandel-kernel.asm
+++ b/mandelbrot/mandel-kernel.asm
@@ -9,13 +9,7 @@
     processor 6502
 mandel:
     ; push registers and state - save on stack
-    php
-    pha
-    txa
-    pha
-    tya
-    pha
-    
+    PUSH_REGISTERS
 
     lda #GREEN
     sta COLUBK
@@ -119,10 +113,5 @@ iterator_loop:
     PLA
 
     ; restore saved registers and state from stack
-    PLA
-    TAY
-    PLA
-    TAX
-    PLA
-    PLP
+    POP_REGISTERS
     rts

--- a/mandelbrot/mandel-kernel.asm
+++ b/mandelbrot/mandel-kernel.asm
@@ -7,7 +7,7 @@
 
 
     processor 6502
-mandel:
+;mandel:
     PUSH_REGISTERS
     lda #GREEN
     sta COLUBK
@@ -28,19 +28,20 @@ mandel:
     sta COLUBK
     POP_REGISTERS
     rts
-
-xmandel:
-;mandel:
+mandel:
     ; push registers and state - save on stack
     PUSH_REGISTERS
-    lda #GREEN
+    lda #ORANGE
     sta COLUBK
 
-    FIXUP zr
-    FIXUP zi
 
     ldy #1              ; indexing with this accesses the high byte 
 
+fixup_zr:
+    FIXUP zr
+fixup_zi:
+    FIXUP zi
+    
     ; Calculate zr^2 + zi^2. 
 
     clc
@@ -53,7 +54,8 @@ xmandel:
     ;cmp #4 << (fraction_bits-8)
     ;cmp #4 << 1    ;; FIXME:  1 is a placeholder
     sta zr2_p_zi2_hi
-    cmp #$f1
+    and #$07
+    cmp #$02
     bcs .bailoutToInfinityAndBeyond
     
 
@@ -65,7 +67,7 @@ xmandel:
     sta zr_p_zi
     lda zr,y            ; A = high(zr) 
     adc zi,y            ; A = high(zr + zi) + C 
-    ; and #$3F
+    and #$f7
     ora #$F0            ; fixup 
     sta zr_p_zi,y
 
@@ -87,7 +89,7 @@ xmandel:
     sta zr
     lda zr2_m_zi2,y     ; A = high(zr^2 - zi^2) 
     adc cr,y            ; A = high(zr^2 - zi^2 + cr) 
-    ; and #$3F
+    and #$f7
     ora #$F0            ; fixup 
     sta zr,y
 
@@ -109,7 +111,7 @@ xmandel:
     sta zi
     tya
     adc ci,y
-    ; and #$3F
+    and #$f7
     ora #$F0            ; fixup 
     sta zi,y
 
@@ -164,6 +166,7 @@ xmandel:
     sta {1}
 
     lda {1},Y  ; high byte, we turn on top 4 bits
+    and #$f7
     ora #$f0
     sta {1},Y
 

--- a/mandelbrot/mandelbrot.asm
+++ b/mandelbrot/mandelbrot.asm
@@ -305,10 +305,15 @@ initMandelVars:
     rts
 
 updatePfbits:
+    lda row
+    asl row
+    tay              ; y should index to PF1 mandelbyte for current row (PF1)
+
     lda col          ; which bit are we updating?
     cmp #8
     bcs .updatePF2    ; equal or greater than 8 -> we are in PF2
-.updatePF1:
+.updatePF1:          ; PF1:  col 01234567 --> bit 76543210
+; col 0 -> bit 7, col 1 -> bit 6, etc
     lda #7
     SEC
     sbc col
@@ -317,23 +322,26 @@ updatePfbits:
     asl pfBit
     ora PF1Shadow
     sta PF1Shadow
+    sta mandelBytes,Y
 
-.updatePF2:
+.updatePF2:          ;  PF2:   col 89abcdef --> bit 01234567
     SEC
-    sbc #8
+    sbc #8            ; PF2 bits are in opposite direction of PF1
+                      ; col 8 -> bit 0, col 9 -> bit 1, etc.  
     sta pfBit
     lda #1
     asl pfBit
     ora PF2Shadow
     sta PF2Shadow     ; fixme - we have to actually update the right field in mandelbytes
-    lda iterations
-    and #$fe
-    beq .blankBit
+    INY               ; one more byte to point at PF2
+    sta mandelBytes,y 
+
+;.blankBitPF1
+
+;.blankBitPF2
+
+    rts  ; seems like we should return here?
     
-
-.blankBit
-
-
 
 nextMandelCol:
     lda col

--- a/mandelbrot/mandelbrot.asm
+++ b/mandelbrot/mandelbrot.asm
@@ -10,7 +10,6 @@
 
 	processor 6502
 	include "vcs.h"
-FLICKERMODE = 0
 MAX_ITERATIONS = 30
 rows = 32  ; number of rows to render (two playfield bytes per row)
 cols = 16  ; number of coloumns to render (half of a mirrored playfield using PF1 and PF2- 16 bits)
@@ -50,11 +49,6 @@ row ds.b 1            ; current column being rendered (0 .. rows)
 col ds.b 1            ; current column (0..15)   (columns 0..7 are in PF1, 8-15 are in PF2)
 pfBitMask ds.b 1          ; bit number of playfield to turn on
 
-
-    if FLICKERMODE
-enableRender ds.b 1
-    ENDIF
-
 BLUE           = $9a         ;              define symbol for TIA color (NTSC)
 ORANGE         = $2c         
 GREEN          = $ca
@@ -83,10 +77,6 @@ clear:                       ;              define a label
 init:
     lda #03
     sta CTRLPF
-    IF FLICKERMODE
-    lda #1
-    sta enableRender
-    ENDIF
     ldy #0
     lda #0
 initMandelBytes:
@@ -131,12 +121,6 @@ verticalBlank:
     lda #BLUE
     sta COLUBK
 	; generate 192 lines of playfield
-    IF FLICKERMODE
-    lda enableRender
-    beq skipRender
-    lda #0
-    sta enableRender
-    ENDIF
 
 startMandelBytes:
     ldx #0
@@ -168,24 +152,7 @@ renderRowCountUp:
     sta WSYNC
     cpy #mandelByteCount
     bne drawMandelBytes
-    jmp startFooter
-    IF FLICKERMODE
-skipRender: ; only if FLICKERMODE is enabled.
-    ldx #0
-    lda #skipRowTimer
-    sta TIM64T
-    lda #1
-    sta enableRender
-loopSkipRender:
-    lda INTIM
-    sta WSYNC
-    bne loopSkipRender
-catchUpRowCount:
-    txa
-    clc
-    adc #skipRows
-    tax
-    ENDIF
+
 startFooter:
     lda #ORANGE
     sta COLUBK
@@ -414,7 +381,6 @@ runNextIter:        ; run next mandelbrot iteration
     beq .runNextIter_bailout   ; skip if we're out of rows to render
 
     jsr mandel
-
     lda keepIterating          ; do we have a result?  If not, bail out
     bne .runNextIter_bailout
 .runNextIter_render            ; we have a thing to render

--- a/mandelbrot/mandelbrot.asm
+++ b/mandelbrot/mandelbrot.asm
@@ -10,12 +10,12 @@
 
 	processor 6502
 	include "vcs.h"
-MAX_ITERATIONS = 32
-rows = 30  ; number of rows to render (two playfield bytes per row)
+MAX_ITERATIONS = 10
+rows = 14  ; number of rows to render (two playfield bytes per row)
 cols = 16  ; number of coloumns to render (half of a mirrored playfield using PF1 and PF2- 16 bits)
 mandelByteCount = 2 * rows
-scanlines_per_row = 5
-tim64_clocks_per_row = 5
+scanlines_per_row = 12
+tim64_clocks_per_row = 13
 TASK_IDLE      = $03
 TASK_ITERATE   = $01
 TASK_UPDATEPF  = $02
@@ -341,11 +341,11 @@ nextMandelCol:   ; advance to next colum (i axis). Advance Ci by one step. Wrapa
     ; therefore each column means we increment in the imaginary direction
     lda ci
     CLC
-    adc #cStep   ; update c to next step in imaginary direction
+    adc cStep   ; update c to next step in imaginary direction
     sta ci
     
     lda ci,y
-    clc
+;    clc
     adc cStep,y
     sta ci,y
     POP_REGISTERS
@@ -375,7 +375,7 @@ nextMandelRow:  ; move cursor to next row
     sta cr
 
     lda cr,y
-    CLC
+    ; CLC
     adc cStep,y
     sta cr,y
 


### PR DESCRIPTION
Mandelbrot renderer is now calling Mandelbrot kernel, and uses a task system to switch between rendering and iterating.

We are not rendering a correct Mandelbrot, but we have a stable screen and are calling mandelbrot calculations.

I fixed some errors in the mandelbrot calculations, especially using the wrong addressing mode for accessing the 'squares' lookup table.  It's still not working, but we are hopefully closer.