### PR TITLE
Mdebreceni/2025 09 14 fix allblack mandelbrot

### DIFF
--- a/mandelbrot-8bit/mandel-8bit-kernel.asm
+++ b/mandelbrot-8bit/mandel-8bit-kernel.asm
@@ -13,8 +13,8 @@
 mandel:
     ; push registers and state - save on stack
     PUSH_REGISTERS
-    lda #ORANGE
-    sta COLUBK
+;    lda #ORANGE
+;    sta COLUBK
     ldy #1
     ; Calculate zr^2 + zi^2. 
     clc
@@ -86,10 +86,10 @@ mandel:
     jmp .return
 
 .return:
-    PHA
-    lda #BLUE
-    sta COLUBK
-    PLA
+;    PHA
+;    lda #BLUE
+;    sta COLUBK
+;    PLA
 
     ; restore saved registers and state from stack
     POP_REGISTERS

--- a/mandelbrot-8bit/mandelbrot-8bit.asm
+++ b/mandelbrot-8bit/mandelbrot-8bit.asm
@@ -84,6 +84,9 @@ init:
     sta CTRLPF
     ldy #0
     lda #0
+    clc
+    cld
+    adc #0
 initMandelBytes:
     ; ora #$f0
     lda #0
@@ -321,12 +324,10 @@ nextMandelCol:   ; advance to next colum (i axis). Advance Ci by one step. Wrapa
     ;   sta col
     ; note that our mandelbrot is rotated 90 degrees to take advantage of a mirrored playfield
     ; therefore each column means we increment in the imaginary direction
-;     lda ci
-;     CLC
-;     ;adc cStep   ; update c to next step in imaginary direction
-;     adc #1
-;     sta ci
-    inc ci
+    lda ci
+    CLC
+    adc cStep   ; update c to next step in imaginary direction
+    sta ci
     lda #$00
     sta zr
     sta zi
@@ -344,12 +345,10 @@ wrapAround:   ; move cursor back to start of row, advance to next row.  Reset Ci
 
 nextMandelRow:  ; move cursor to next row
     inc row
-    inc cr
-:     lda cr      ; add one step to c (lo and then hi)
-;     clc
-;     ;adc cStep
-;     adc #1
-;     sta cr
+    lda cr      ; add one step to c (lo and then hi)
+    clc
+    adc cStep
+    sta cr
 
     POP_REGISTERS
     rts  


### PR DESCRIPTION
Fixed all-black Mandelbrot by putting 6507 status register in a known state during initialization
- Disable decimal mode
- Clear carry flag
- Calculate 0 + 0 to force clear Zero and Negative flags
